### PR TITLE
Remove redundant lang attribute from meta tag

### DIFF
--- a/html+css/1.html
+++ b/html+css/1.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="uk">
     <head>
-        <meta charset="UTF-8" lang = "">
+        <meta charset="UTF-8">
         <tittle></tittle>
         <link rel="stylesheet" href="style.css">
         <script src="screept.js"></script>


### PR DESCRIPTION
## Summary
- remove empty `lang` attribute from `<meta charset>` tag in `html+css/1.html`

## Testing
- `npm test` (fails: ENOENT no package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5d8c0ea98833382a312862b1b5025